### PR TITLE
[fetchit] Catch AttributeErrors when crawling MyFitnessPal

### DIFF
--- a/apps/fetchit/fetchit.py
+++ b/apps/fetchit/fetchit.py
@@ -28,14 +28,25 @@ def main():
     mfp_api = MyFitnessPalAPI()
     rk_api = RunKeeperAPI()
 
+    # TODO: Write a central process that loads modules and handles errors,
+    #       and whether or not to cache
     # TODO: Get from cache, and pass to api class to replace not found data
     while 1:
         gh_details = gh_api.fetch_details()
         conn.set_json('github_data', gh_details)
         temp = weather_api.current_temp(gh_details['location'])
         conn.set_json('temp_f', temp)
-        conn.set_json('myfitnesspal_data', mfp_api.fetch_details())
         conn.set_json('runkeeper_data', rk_api.fetch_details())
+
+        # Since MFP is crawling HTML, let's catch funniness with returned page
+        try:
+            mfp_details = mfp_api.fetch_details()
+            conn.set_json('myfitnesspal_data', mfp_details)
+        except AttributeError as e:
+            log.error(
+                "Error when crawling/storing MyFitnessPal data. "
+                "(exception: %s)" % str(e)
+            )
         log.info("Data cached successfully!")
         # TODO: Catch CTRL-C or CTRL-Z and do some cleanup
 


### PR DESCRIPTION
Ran into error where MyFitnessPal was returning a 502 and the crawl would fail with an AttributeError exception. The crawler wouldn't fail permanently, but caused a burst of API calls as it just continued trying again and again. This will catch the AttributeError from MyFitnessPal, log the error, but then continue without changing what's in our cache.

Wunderground API Calls
<img width="633" alt="screen shot 2017-03-13 at 12 41 54 pm" src="https://cloud.githubusercontent.com/assets/1171118/23872161/79b1d7ae-07ea-11e7-809a-bfea3773d7c3.png">


The next step here is to refactor our crawler into a new scheme. We'd need a central process that loads the API crawlers' individually, calling common methods, and doing common error handling so we can avoid repetitive code.